### PR TITLE
Allow file upload using chunks.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,16 @@
 const spauth = require('node-sp-auth')
 const axios = require('axios')
 
+const getGUID = () => {
+  let d = Date.now();
+  const guid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (d + Math.random() * 16) % 16 | 0; //eslint-disable-line
+    d = Math.floor(d / 16);
+    return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16); //eslint-disable-line
+  });
+  return guid;
+};
+
 class Sharepoint {
   constructor (url) {
     if (!url) {
@@ -156,6 +166,100 @@ class Sharepoint {
         'X-RequestDigest': formDigestValue
       }
     })
+  }
+
+  async createFileChunked (options) {
+    const {
+      dirPath, fileName, stream, fileSize,
+    } = options;
+    const chunkSize = options.chunkSize || 65536;
+    this.checkHeaders();
+    const formDigestValue = await this.getFormDigestValue();
+
+    await this.createFile({
+      dirPath,
+      fileName,
+      data: ' ',
+    });
+
+    const uploadId = getGUID();
+
+    let firstChunk = true;
+    let sent = 0;
+    const self = this;
+
+
+    const upload = new Promise(function(resolve, reject) {
+      stream.on('data', async (data) => {
+        try {
+          stream.pause();
+          if (firstChunk) {
+            firstChunk = false;
+            const response = await axios({
+              method: 'post',
+              url: `${self.url}/_api/web/getfilebyserverrelativeurl('${self.site.serverRelativeUrl}${dirPath}/${fileName}')/startupload(uploadId=guid'${uploadId}')`,
+              data,
+              headers: {
+                ...self.headers,
+                'X-RequestDigest': formDigestValue,
+              },
+            });
+            sent = Number(response.data.d.StartUpload);
+          } else if (sent + chunkSize >= fileSize) {
+            await axios({
+              method: 'post',
+              url: `${self.url}/_api/web/getfilebyserverrelativeurl('${self.site.serverRelativeUrl}${dirPath}/${fileName}')/finishupload(uploadId=guid'${uploadId}',fileoffset=${sent})`,
+              data,
+              headers: {
+                ...self.headers,
+                'X-RequestDigest': formDigestValue,
+              },
+            });
+            resolve();
+          } else {
+            const response = await axios({
+              method: 'post',
+              url: `${self.url}/_api/web/getfilebyserverrelativeurl('${self.site.serverRelativeUrl}${dirPath}/${fileName}')/continueupload(uploadId=guid'${uploadId}',fileoffset=${sent})`,
+              data,
+              headers: {
+                ...self.headers,
+                'X-RequestDigest': formDigestValue,
+              },
+            });
+            sent = Number(response.data.d.ContinueUpload);
+          }
+          stream.resume();
+        } catch (e) {
+          stream.destroy();
+          await axios({
+            method: 'post',
+            url: `${self.url}/_api/web/getfilebyserverrelativeurl('${self.site.serverRelativeUrl}${dirPath}/${fileName}')/cancelupload(uploadId=guid'${uploadId}')`,
+            data,
+            headers: {
+              ...self.headers,
+              'X-RequestDigest': formDigestValue,
+            },
+          });
+          reject();
+        }
+      });
+  
+      stream.on('error', async (data) => {
+        const response = await axios({
+          method: 'post',
+          url: `${self.url}/_api/web/getfilebyserverrelativeurl('${self.site.serverRelativeUrl}${dirPath}/${fileName}')/cancelupload(uploadId=guid'${uploadId}')`,
+          data,
+          headers: {
+            ...self.headers,
+            'X-RequestDigest': formDigestValue,
+          },
+        });
+        reject(); 
+      })
+    });
+
+    await upload;
+
   }
 
   async deleteFile (options) {

--- a/test/test.js
+++ b/test/test.js
@@ -240,6 +240,19 @@ describe('Tests', function () {
     expect(contents.map(i => i.Name).includes(FILE_NAME_1)).to.eql(true)
   })
 
+  it('upload file read in from fixtures using chunks', async () => {
+    const filePath = path.resolve(__dirname, 'fixtures', FILE_NAME_1);
+    const stats = fs.statSync(filePath)
+    const stream = fs.createReadStream(filePath, { highWaterMark: 1024 * 2 });
+    await sharepoint.createFileChunked({
+      dirPath: `${process.env.SHAREPOINT_DIR_PATH}/${FOLDER_NAME}`,
+      fileName: FILE_NAME,
+      stream,
+      fileSize:stats.size,
+      chunkSize: 1024 * 2,
+    });
+  })
+
   it('delete a folder', async () => {
     await sharepoint.deleteFolder({
       dirPath: process.env.SHAREPOINT_DIR_PATH,


### PR DESCRIPTION
Added `createFileChunked` method to allow uploading files using streams and chunks. (See #1) 

It's based on the `/startupload`, `/continueupload`, `/finishupload` and `/cancelupload` endpoints (See https://msdn.microsoft.com/en-us/library/office/dn450841.aspx).

 Let me know if you have any questions/observations.

Merry Christmas! 